### PR TITLE
Fix typo: pyhtonium -> pythonium

### DIFF
--- a/docs/source/tutorial/01_first_player.rst
+++ b/docs/source/tutorial/01_first_player.rst
@@ -31,7 +31,7 @@ Put this code inside a python file:
 
 .. code-block:: python
 
-   from pyhtonium import AbstractPlayer
+   from pythonium import AbstractPlayer
 
    class Player(AbstractPlayer):
 
@@ -58,7 +58,7 @@ Let's save now this file as ``my_player.py`` (or whatever name you like) and exe
 
 .. code-block:: bash
 
-    $ pyhtonium --player my_player
+    $ pythonium --player my_player
     ** Pythonium **
     Running battle in Galaxy #PBA5V2
     Playing game.....................................

--- a/docs/source/tutorial/02_understanding_the_unknown.rst
+++ b/docs/source/tutorial/02_understanding_the_unknown.rst
@@ -32,7 +32,7 @@ Open the player you built in :ref:`Chapter 1<Tutorial Chapter 01>` and set a tra
 
 .. code-block:: python
 
-    from pyhtonium import AbstractPlayer
+    from pythonium import AbstractPlayer
 
     class Player(AbstractPlayer):
 


### PR DESCRIPTION
It fixed typos that we saw on the pycamp demo